### PR TITLE
remove time_zone from time_format_in_parts

### DIFF
--- a/test_efs/dsgrid_project/datasets/modeled/comstock_time_in_parts/dataset_full_missing.json5
+++ b/test_efs/dsgrid_project/datasets/modeled/comstock_time_in_parts/dataset_full_missing.json5
@@ -79,7 +79,6 @@
         month_column: "month",
         day_column: "day",
         hour_column: "hour",
-        time_zone: "Etc/GMT+5",
       },
     },
   ],


### PR DESCRIPTION
time_format_in_parts does not support time_zone param, just offset.